### PR TITLE
Add support for attaching multiple EBS volumes.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,12 +43,12 @@ resource "aws_launch_configuration" "ecs" {
     delete_on_termination = true
   }
 
-  ebs_block_device {
+  ebs_block_device = ["${concat(list({
     device_name           = "/dev/xvdcz"
     volume_size           = "${var.docker_storage_size}"
     volume_type           = "${var.docker_storage_type}"
     delete_on_termination = true
-  }
+  }), $var.ebs_block_devices)}"]
 
   user_data = "${coalesce(var.user_data, data.template_file.user_data.rendered)}"
 

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_launch_configuration" "ecs" {
     delete_on_termination = true
   }
 
-  ebs_block_device = ["${local.docker_container_storage}"]
+  ebs_block_device = "${local.docker_container_storage}"
 #  ebs_block_device = ["${concat(local.docker_container_storage, var.ebs_block_devices)}"]
 
   user_data = "${coalesce(var.user_data, data.template_file.user_data.rendered)}"

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,8 @@ resource "aws_launch_configuration" "ecs" {
     delete_on_termination = true
   }
 
-  ebs_block_device = ["${concat(local.docker_container_storage, var.ebs_block_devices)}"]
+  ebs_block_device = ["${local.docker_container_storage}"]
+#  ebs_block_device = ["${concat(local.docker_container_storage, var.ebs_block_devices)}"]
 
   user_data = "${coalesce(var.user_data, data.template_file.user_data.rendered)}"
 

--- a/main.tf
+++ b/main.tf
@@ -53,8 +53,7 @@ resource "aws_launch_configuration" "ecs" {
     delete_on_termination = true
   }
 
-  ebs_block_device = "${local.docker_container_storage}"
-#  ebs_block_device = ["${concat(local.docker_container_storage, var.ebs_block_devices)}"]
+  ebs_block_device = "${concat(local.docker_container_storage, var.ebs_block_devices)}"
 
   user_data = "${coalesce(var.user_data, data.template_file.user_data.rendered)}"
 

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,16 @@ data "aws_vpc" "vpc" {
   id = "${var.vpc_id}"
 }
 
+
+locals {
+  docker_container_storage = [{
+    device_name           = "/dev/xvdcz"
+    volume_size           = "${var.docker_storage_size}"
+    volume_type           = "${var.docker_storage_type}"
+    delete_on_termination = true
+  }]
+}
+
 resource "aws_launch_configuration" "ecs" {
   name_prefix                 = "${coalesce(var.name_prefix, "ecs-${var.name}-")}"
   image_id                    = "${var.ami == "" ? format("%s", data.aws_ami.ecs_ami.id) : var.ami}"   # Workaround until 0.9.6
@@ -43,12 +53,7 @@ resource "aws_launch_configuration" "ecs" {
     delete_on_termination = true
   }
 
-  ebs_block_device = ["${concat([{
-    device_name           = "/dev/xvdcz"
-    volume_size           = "${var.docker_storage_size}"
-    volume_type           = "${var.docker_storage_type}"
-    delete_on_termination = true
-  }], $var.ebs_block_devices)}"]
+  ebs_block_device = ["${concat(local.docker_container_storage, var.ebs_block_devices)}"]
 
   user_data = "${coalesce(var.user_data, data.template_file.user_data.rendered)}"
 

--- a/main.tf
+++ b/main.tf
@@ -43,12 +43,12 @@ resource "aws_launch_configuration" "ecs" {
     delete_on_termination = true
   }
 
-  ebs_block_device = ["${concat(list({
+  ebs_block_device = ["${concat([{
     device_name           = "/dev/xvdcz"
     volume_size           = "${var.docker_storage_size}"
     volume_type           = "${var.docker_storage_type}"
     delete_on_termination = true
-  }), $var.ebs_block_devices)}"]
+  }], $var.ebs_block_devices)}"]
 
   user_data = "${coalesce(var.user_data, data.template_file.user_data.rendered)}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,6 @@ variable "docker_storage_type" {
   description = "EBS Volume type that the ECS Instance uses for Docker images and metadata "
 }
 
-
 variable "dockerhub_email" {
   default     = ""
   description = "Email Address used to authenticate to dockerhub. http://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html"
@@ -149,4 +148,9 @@ variable "load_balancers" {
 
 variable "vpc_id" {
   description = "The AWS VPC ID which you want to deploy your instances"
+}
+
+variable "ebs_block_devices" {
+  type    = "list"
+  default = []
 }


### PR DESCRIPTION
So the `/dev/xvdcz` device is basically for storing the root image for the Docker container. This allows us to create more EBS block devices to use for, say, Docker volumes and such.